### PR TITLE
xbuild.config: configure sourceRoot to address esbuild sourcemap

### DIFF
--- a/xbuild.config.ts
+++ b/xbuild.config.ts
@@ -27,7 +27,7 @@ const config: Array<xBuildConfig> = [
             platform: 'browser',
             packages: 'external',
             sourcemap: true,
-            sourceRoot: `https://github.com/remotex-labs/xjet-expect/tree/v${ pkg.version }/`,
+            sourceRoot: `https://github.com/remotex-labs/xjet-expect/tree/v${ pkg.version }///`,
             minifySyntax: true,
             preserveSymlinks: true,
             minifyWhitespace: true,


### PR DESCRIPTION
This works around the issue described in:
https://github.com/evanw/esbuild/issues/4298#issuecomment-3388003885